### PR TITLE
Correct return type so build passes

### DIFF
--- a/src/engine/arrayview3d.h
+++ b/src/engine/arrayview3d.h
@@ -173,7 +173,7 @@ public:
         return view;
     }
 
-    void getViewAsArray3d(Array3d<T> &view) {
+    Array3d<T> getViewAsArray3d(Array3d<T> &view) {
         if (!(view.width == width && view.height == height && view.depth = depth)) {
             std::string msg = "Error: array dimensions must be equal to view dimensions.\n";
             msg += "width: " + _toString(width) + 


### PR DESCRIPTION
`getViewAsArray3d(Array3d<T> &view)` Was typed to return `void` instead of `Array3d<T>`, which cause the build to fail. Corrected it and build passes.