### PR TITLE
Added support for gcc 11

### DIFF
--- a/src/engine/trianglemesh.h
+++ b/src/engine/trianglemesh.h
@@ -28,6 +28,7 @@ SOFTWARE.
 #include <string>
 #include <vector>
 #include <sstream>
+#include <limits>
 
 #include "vmath.h"
 #include "triangle.h"


### PR DESCRIPTION
With gcc 11, numeric limits is no longer included in std, so you have to manually import it. I added it the the trianglemesh.h header, however I'm not too familiar with c++, so this may be the wrong place to put it. 