### PR TITLE
Fix incorrect casing in include

### DIFF
--- a/src/engine/stopwatch.h
+++ b/src/engine/stopwatch.h
@@ -28,8 +28,8 @@ SOFTWARE.
 #if defined(__linux__) || defined(__APPLE__) || defined(__MACOSX)
     #include <sys/time.h>
 #elif defined(_WIN32)
-    #include <Windows.h>
-    #include <Winbase.h>
+    #include <windows.h>
+    #include <winbase.h>
 #else
 #endif
 


### PR DESCRIPTION
Only matters when compiling on a case-sensitive filesystem.